### PR TITLE
建议去除onSaveInstanceXXX() onStop() onPause()调用顺序的对比

### DIFF
--- a/Part1/Android/Android基础知识.md
+++ b/Part1/Android/Android基础知识.md
@@ -135,9 +135,6 @@ Activity的堆栈管理以ActivityRecord为单位,所有的ActivityRecord都放�
 
 3.由于onSaveInstanceState()方法调用的不确定性，你应该只使用这个方法去记录activity的瞬间状态（UI的状态）。不应该用这个方法去存储持久化数据。当用户离开这个activity的时候应该在onPause()方法中存储持久化数据（例如应该被存储到数据库中的数据）。
  
-4.onSaveInstanceState()如果被调用，这个方法会在onStop()前被触发，但系统并不保证是否在onPause()之前或者之后触发。
- 
- 
 二、onRestoreInstanceState (Bundle outState)
 
 至于onRestoreInstanceState方法，需要注意的是，onSaveInstanceState方法和onRestoreInstanceState方法“不一定”是成对的被调用的，（本人注：我昨晚调试时就发现原来不一定成对被调用的！）


### PR DESCRIPTION
开发者只要知道onSaveInstanceState()调用的不确定性就足够了。而且这个方法在AppCompatActivity和Activity中的解释是有冲突的。
- AppCompatActivity的文档有如下解释
If called, this method will occur after onStop for applications targeting platforms starting with Build.VERSION_CODES.P. For applications targeting earlier platform versions this method will occur before onStop and there are no guarantees about whether it will occur before or after onPause.
- Activity 的文档有如下解释
If called, this method will occur before onStop(). There are no guarantees about whether it will occur before or after onPause().